### PR TITLE
Pass Server from WebSocketPair for on[event] handlers

### DIFF
--- a/src/replica.ts
+++ b/src/replica.ts
@@ -111,7 +111,7 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 		let closer = async (evt: Event) => {
 			try {
 				if (evt.type === 'error' && this.onerror) await this.onerror(socket);
-				else if (this.onclose) await this.onclose(socket);
+				else if (this.onclose) await this.onclose(socket, server);
 			} finally {
 				let state = this.#pool.get(rid);
 				let isEmpty: boolean;
@@ -135,12 +135,12 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 
 		if (this.onmessage) {
 			server.addEventListener('message', evt => {
-				this.onmessage!(socket, evt.data);
+				this.onmessage!(socket, evt.data, server);
 			});
 		}
 
 		if (this.onopen) {
-			await this.onopen(socket);
+			await this.onopen(socket, server);
 		}
 
 		let state: DOG.State = this.#pool.get(rid) || {

--- a/src/replica.ts
+++ b/src/replica.ts
@@ -111,7 +111,7 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 		let closer = async (evt: Event) => {
 			try {
 				if (evt.type === 'error' && this.onerror) await this.onerror(socket);
-				else if (this.onclose) await this.onclose(socket, server);
+				else if (this.onclose) await this.onclose(socket);
 			} finally {
 				let state = this.#pool.get(rid);
 				let isEmpty: boolean;
@@ -135,7 +135,7 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 
 		if (this.onmessage) {
 			server.addEventListener('message', evt => {
-				this.onmessage!(socket, evt.data, server);
+				this.onmessage!(socket, evt.data);
 			});
 		}
 


### PR DESCRIPTION
Sometimes I need to work directly on the `server` instance from the pair, such as adding my own custom logic after using the `onopen` handler and `connect()` in the Durable Object.

I have a custom Server class (`this.server`) that can accept new connections, and runs some custom logic for `serverFromPair`.

I cannot use `Socket`, as it gets reinitialized each time. I need a strong reference to the original server from `WebSocketPair()`.

```ts
async onopen(socket: Socket, serverFromPair: WebSocket): Promise<void> {
  await this.server.createNewConnection( // <--- I have some custom logic that needs serverFromPair
    new WebSocketWrapper(server), // <-- I have custom functions in WebSocketWrapper
  );
}
```