### PR TITLE
[fix] Soft close the server (as it can be closed in `onclose` or `onerror`)

### DIFF
--- a/src/replica.ts
+++ b/src/replica.ts
@@ -130,7 +130,7 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 				try {
 					server.close();
 				} catch (e) {
-					//
+					// already closed
 				}
 			}
 		}

--- a/src/replica.ts
+++ b/src/replica.ts
@@ -126,7 +126,11 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 				}
 
 				await this.#close(rid, gid, isEmpty);
-				server.close();
+				try {
+					server.close();
+				} catch (e) {
+					//
+				}
 			}
 		}
 

--- a/src/replica.ts
+++ b/src/replica.ts
@@ -126,6 +126,7 @@ export abstract class Replica<T extends ModuleWorker.Bindings> implements DOG.Re
 				}
 
 				await this.#close(rid, gid, isEmpty);
+
 				try {
 					server.close();
 				} catch (e) {


### PR DESCRIPTION
I have some custom logic in `onerror()` that will close the connection with a custom code:

```typescript
class DO extends Replica<Bindings> {
  async onerror() {
    // Logic to handle the error
    // ...

    // See: https://www.iana.org/assignments/websocket/websocket.xhtml
    return ws.close(1012);
  }
}
```

Not having a try-catch on `.close()` will lead to this:

```bash
[mf:err] Unhandled Promise Rejection: TypeError: WebSocket already closed
```

Not sure if this breaks something.