### PR TITLE
Add warning that this project should not be used in production

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,3 @@
-
 on:
   pull_request: {}
   workflow_dispatch: {}
@@ -12,14 +11,14 @@ name: Semgrep config
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       SEMGREP_URL: https://cloudflare.semgrep.dev
       SEMGREP_APP_URL: https://cloudflare.semgrep.dev
       SEMGREP_VERSION_CHECK_URL: https://cloudflare.semgrep.dev/api/check-version
     container:
-      image: returntocorp/semgrep
+      image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: semgrep ci

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+🚧 This project is not suitable for production usage 🚧
+
 # DOG [![CI](https://github.com/lukeed/dog/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/lukeed/dog/actions/workflows/ci.yml)
 
 > Durable Object Groups


### PR DESCRIPTION
We should archive this project as it is not being actively used or maintained by Cloudflare. I have added a warning to the README that this project should not be used in production. It has only recently come to our attention that Cloudflare created this library. For those looking for a Durable Object utility library, they should consider https://github.com/lambrospetrou/durable-utils. 